### PR TITLE
Add netaddr package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION = $(shell cat ansible-version.txt)
 
 all:
 	@echo "Making vendored Ansible package for $(VERSION)"
-	pip install --install-option="--prefix=/ansible" ansible==$(VERSION)
+	pip install --install-option="--prefix=/ansible" ansible==$(VERSION) netaddr
 	tar -zcf ansible.tar.gz /ansible
 
 .PHONY: clean


### PR DESCRIPTION
To use the ipaddr filters in ansible, the netaddr package must be installed.

http://docs.ansible.com/ansible/latest/playbooks_filters_ipaddr.html